### PR TITLE
Change recommendation to bits_per_pixel rather than bit_rate and add recommendation for profile

### DIFF
--- a/docs/NMOS With JPEG XS.md
+++ b/docs/NMOS With JPEG XS.md
@@ -30,7 +30,16 @@ This has been permitted since IS-04 v1.1.
 
 Nodes implementing [BCP-004-01][] Receiver Capabilities use the existing `constraint_sets` parameter within the `caps` object, describing combinations of frame rates, width and height, and other parameters which the receiver can support, using the parameter constraints defined in the [Capabilities register](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/) of the [NMOS Parameter Registers][].
 
-If the Receiver supports streams meeting the traffic shaping and delivery timing requirements for ST 2110-22, it SHOULD use the `urn:x-nmos:cap:transport:st2110_21_sender_type` parameter constraint.
+Receivers are RECOMMENDED to use the following parameter constraints:
+
+- [Frame Width](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#frame-width)
+- [Frame Height](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#frame-width)
+- [Color Sampling](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#color-sampling)
+- [Component Depth](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#component-depth)
+- [Bits Per Pixel](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#bits-per-pixel)
+- [Profile](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#profile)
+
+If the Receiver supports streams meeting the traffic shaping and delivery timing requirements for ST 2110-22, it SHOULD use the [ST 2110-21 Sender Type](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#st-2110-21-sender-type) parameter constraint.
 
 An example Receiver resource is provided in the [Examples](../examples/).
 
@@ -51,11 +60,10 @@ If the Sender meets the traffic shaping and delivery timing requirements specifi
 The Flow resource MUST indicate `video/jxsv` in the `media_type` attribute, and `urn:x-nmos:format:video` for the `format`.
 This has been permitted since IS-04 v1.1.
 
-Nodes implementing IS-04 v1.3 or higher MUST indicate the color (sub-)sampling in the Flow resource using the `components` attribute defined in the [Flow Attributes register](https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/) of the NMOS Parameter Registers.
+Nodes implementing IS-04 v1.3 or higher MUST indicate the color (sub-)sampling in the Flow resource using the `components` attribute defined in the [Flow Attributes register](https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/#components) of the NMOS Parameter Registers.
 The `components` array value corresponds to the `sampling`, `width` and `height` values in the SDP format-specific parameters defined by RFC 9134.
 
-Nodes implementing IS-04 v1.3 or higher MUST indicate the stream bit rate in the Flow resource using the `bit_rate` attribute also defined in the Flow Attributes register.
-The bit rate value also appears in the SDP file, per RFC 9134.
+Nodes implementing IS-04 v1.3 or higher MUST indicate the coding tools in use, and the compression ratio of the stream, in the Flow resource using the `profile` and `bits_per_pixel` attributes also defined in the Flow Attributes register.
 
 An example Flow resource is provided in the [Examples](../examples/).
 


### PR DESCRIPTION
This PR addresses initial implementation feedback within the AMWA NMOS Cloud Testbed + New Formats ad-hoc group, in switching the JPEG XS expression of compression ratio from Bit Rate to Bits Per Pixel, and in introducing Profile as a Flow attribute and Receiver parameter constraint.

Rationale:

* ST 2110-22 SDP b=AS: bit rate includes packetization overhead; not a good Flow param
* For intra-frame only codecs, bit rate and frame rate constraints don’t work well together
* JPEG XS compression is naturally expressed as bits per pixel (and RFC 9134 doesn’t require SDP `b=AS:` bit rate)

This PR resolves #6 and will enable #5 to be resolved.

Note that this doesn't yet update the example files included in this repo:

* the example SDP file probably ought to get `b=AS:` bandwidth value as per ST 2110-22 (although this spec supports RFC 9134 streams _without_ ST 2110-22)
* the example Flow definitely needs `profile` and `bits_per_pixel`
* the example Receiver resource needs updating to resolve #5 (which becomes possible after this change) 

This relies on https://github.com/AMWA-TV/nmos-parameter-registers/pull/38.
