### PR TITLE
Specify Flow and Sender attributes and related Receiver parameter constraints

### DIFF
--- a/docs/NMOS With JPEG XS.md
+++ b/docs/NMOS With JPEG XS.md
@@ -42,21 +42,24 @@ For Nodes implementing IS-04 v1.3 or higher, the following additional requiremen
 
 In addition to those attributes defined in IS-04 for all coded video Flows, the following attributes defined in the [Flow Attributes register](https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/) of the [NMOS Parameter Registers][] are used for JPEG XS.
 
+These attributes provide information for Controllers and Users to evaluate stream compatibility between Senders and Receivers.
+
 - [Components](https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/#components)  
   The Flow resource MUST indicate the color (sub-)sampling using the `components` attribute.
   The `components` array value corresponds to the `sampling`, `width` and `height` values in the SDP format-specific parameters defined by RFC 9134.
 - [Profile](https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/#profile)  
-  The Flow resource MUST indicate the JPEG XS profile, which defines limits on the required algorithmic features and parameter ranges used in the codestream.
+  The Flow resource is strongly RECOMMENDED to indicate the JPEG XS profile, which defines limits on the required algorithmic features and parameter ranges used in the codestream.
   The permitted `profile` values are strings, defined as per RFC 9134.
+  The Unrestricted profile is indicated by omitting this attribute.
 - [Level](https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/#level)  
-  The Flow resource MUST indicate the JPEG XS level, which defines a lower bound on the required throughput for a decoder in the image (or decoded) domain.
+  The Flow resource is strongly RECOMMENDED to indicate the JPEG XS level, which defines a lower bound on the required throughput for a decoder in the image (or decoded) domain.
   The permitted `level` values are strings, defined as per RFC 9134.
+  The Unrestricted level is indicated by omitting this attribute.
 - [Sublevel Bits Per Pixel](https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/#sublevel-bits-per-pixel)  
-  The JPEG XS sublevel defines a lower bound on the required throughput for a decoder in the codestream (or coded) domain.
-  When the `sublevel_bpp` attribute is omitted, the Full (or Unrestricted) sublevel is implied.
-  Otherwise, the `sublevel_bpp` value SHOULD indicate the compression ratio used by the encoder in bits per pixel as a number.
-  When the precise value is not available, the value MUST be set based on the sublevel indicated in the codestream or in the SDP format-specific parameters defined by RFC 9134.
-  For example, `Sublev6bpp` is indicated by the value `6`.
+  The Flow resource is strongly RECOMMENDED to indicate the JPEG XS sublevel, which defines a lower bound on the required throughput for a decoder in the codestream (or coded) domain.
+  The permitted `sublevel_bpp` values are integers, expressed in bits per pixel (BPP), corresponding to the sublevel.   
+  The Full sublevel is indicated by the number of bits per component multiplied by the number of components in the uncompressed image.
+  The Unrestricted sublevel is indicated by omitting this attribute.
 - [Bit Rate](https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/#bit-rate)  
   The Flow resource SHOULD indicate the target bit rate (kilobits/second) of the codestream.
   The `bit_rate` integer value is expressed in units of 1000 bits per second, rounding up.
@@ -97,7 +100,8 @@ Receivers are RECOMMENDED to use the following parameter constraints:
 - [Profile](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#profile)
 - [Level](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#level)
 - [Sublevel Bits Per Pixel](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#sublevel-bits-per-pixel)  
-  When the JPEG XS decoder supports the Full (or Unrestricted) sublevel, the Receiver MAY indicate that this parameter is unconstrained, as per BCP-004-01.
+
+When the JPEG XS decoder supports the Unrestricted profile, level or sublevel, the Receiver MAY indicate that the parameter is unconstrained, as described in BCP-004-01.
 
 Receivers SHOULD also use other parameter constraints, such as those on coded video Flow and Sender attributes, where appropriate:
 

--- a/docs/NMOS With JPEG XS.md
+++ b/docs/NMOS With JPEG XS.md
@@ -128,5 +128,5 @@ An example SDP file is provided in the [Examples](../examples/).
 [IS-04]: https://specs.amwa.tv/is-04/ "AMWA IS-04 NMOS Discovery and Registration Specification"
 [IS-05]: https://specs.amwa.tv/is-05/ "AMWA IS-05 NMOS Device Connection Management Specification"
 [NMOS Parameter Registers]: https://specs.amwa.tv/nmos-parameter-registers/ "Common parameter values for AMWA NMOS Specifications"
-[TR-08]: https://vsf.tv/download/technical_recommendations/VSF_TR-08_2021-08-09.pdf "Transport of JPEG XS Video in ST 2110-22"
+[TR-08]: https://vsf.tv/download/technical_recommendations/VSF_TR-08_2022-04-20.pdf "Transport of JPEG XS Video in ST 2110-22"
 [VSF]: https://vsf.tv/ "Video Services Forum"

--- a/docs/NMOS With JPEG XS.md
+++ b/docs/NMOS With JPEG XS.md
@@ -38,11 +38,25 @@ The Source is therefore unaffected by the use of JPEG XS compression.
 The Flow resource MUST indicate `video/jxsv` in the `media_type` attribute, and `urn:x-nmos:format:video` for the `format`.
 This has been permitted since IS-04 v1.1.
 
-Nodes implementing IS-04 v1.3 or higher MUST indicate the color (sub-)sampling in the Flow resource using the `components` attribute defined in the [Flow Attributes register](https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/) of the NMOS Parameter Registers.
-The `components` array value corresponds to the `sampling`, `width` and `height` values in the SDP format-specific parameters defined by RFC 9134.
+For Nodes implementing IS-04 v1.3 or higher, the following additional requirements on the Flow resource apply.
 
-Nodes implementing IS-04 v1.3 or higher MUST indicate the stream bit rate in the Flow resource using the `bit_rate` attribute also defined in the Flow Attributes register.
-The bit rate value also appears in the SDP file, per RFC 9134.
+In addition to those attributes defined in IS-04 for all coded video Flows, the following attributes defined in the [Flow Attributes register](https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/) of the [NMOS Parameter Registers][] are used for JPEG XS.
+
+- [Components](https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/#components)  
+  The Flow resource MUST indicate the color (sub-)sampling using the `components` attribute.
+  The `components` array value corresponds to the `sampling`, `width` and `height` values in the SDP format-specific parameters defined by RFC 9134.
+- [Profile](https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/#profile)  
+  The Flow resource MUST indicate the JPEG XS profile, which defines limits on the required algorithmic features and parameter ranges used in the codestream.
+  The permitted `profile` values are strings, defined as per RFC 9134.
+- [Level](https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/#level)  
+  The Flow resource MUST indicate the JPEG XS level, which defines a lower bound on the required throughput for a decoder in the image (or decoded) domain.
+  The permitted `level` values are strings, defined as per RFC 9134.
+- [Sublevel Bits Per Pixel](https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/#sublevel-bits-per-pixel)  
+  The JPEG XS sublevel defines a lower bound on the required throughput for a decoder in the codestream (or coded) domain.
+  When the `sublevel_bpp` attribute is omitted, the Full (or Unrestricted) sublevel is implied.
+  Otherwise, the `sublevel_bpp` value SHOULD indicate the compression ratio used by the encoder in bits per pixel as a number.
+  When the precise value is not available, the value MUST be set based on the sublevel indicated in the codestream or in the SDP format-specific parameters defined by RFC 9134.
+  For example, `Sublev6bpp` is indicated by the value `6`.
 
 An example Flow resource is provided in the [Examples](../examples/).
 
@@ -59,9 +73,23 @@ If the Sender meets the traffic shaping and delivery timing requirements specifi
 Nodes capable of receiving JPEG XS video streams MUST have a Receiver resource in the IS-04 Node API, which lists `video/jxsv` in the `media_types` array within the `caps` object.
 This has been permitted since IS-04 v1.1.
 
-Nodes implementing [BCP-004-01][] Receiver Capabilities use the existing `constraint_sets` parameter within the `caps` object, describing combinations of frame rates, width and height, and other parameters which the receiver can support, using the parameter constraints defined in the [Capabilities register](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/) of the [NMOS Parameter Registers][].
+Nodes implementing [BCP-004-01][] Receiver Capabilities use the existing `constraint_sets` parameter within the `caps` object, describing combinations of frame rates, width and height, and other parameters which the receiver can support, using the parameter constraints defined in the [Capabilities register](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/) of the NMOS Parameter Registers.
 
-If the Receiver supports streams meeting the traffic shaping and delivery timing requirements for ST 2110-22, it SHOULD use the `urn:x-nmos:cap:transport:st2110_21_sender_type` parameter constraint.
+Receivers are RECOMMENDED to use the following parameter constraints:
+
+- [Profile](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#profile)
+- [Level](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#level)
+- [Sublevel Bits Per Pixel](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#sublevel-bits-per-pixel)  
+  When the JPEG XS decoder supports the Full (or Unrestricted) sublevel, the Receiver MAY indicate that this parameter is unconstrained, as per BCP-004-01.
+
+Receivers SHOULD also use other parameter constraints, such as those on coded video Flow attributes, where appropriate:
+
+- [Frame Width](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#frame-width)
+- [Frame Height](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#frame-height)
+- [Color Sampling](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#color-sampling)
+- [Component Depth](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#component-depth)
+
+If the Receiver supports streams meeting the traffic shaping and delivery timing requirements for ST 2110-22, it SHOULD use the [ST 2110-21 Sender Type](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#st-2110-21-sender-type) parameter constraint.
 
 An example Receiver resource is provided in the [Examples](../examples/).
 

--- a/docs/NMOS With JPEG XS.md
+++ b/docs/NMOS With JPEG XS.md
@@ -71,6 +71,20 @@ Sender resources provide no indication of media type or format, since this is de
 The SDP file at the `manifest_href` MUST comply with the requirements of RFC 9134.
 If the Sender meets the traffic shaping and delivery timing requirements specified for ST 2110-22, the SDP file MUST also comply with the provisions of ST 2110-22.
 
+For Nodes implementing IS-04 v1.3 or higher, the following additional requirements on the Sender resource apply.
+
+In addition to those attributes defined in IS-04 for Senders, the following attributes defined in the [Sender Attributes register](https://specs.amwa.tv/nmos-parameter-registers/branches/main/sender-attributes/) of the NMOS Parameter Registers are used for JPEG XS.
+
+- [Bit Rate](https://specs.amwa.tv/nmos-parameter-registers/branches/main/sender-attributes/#bit-rate)  
+  If the Sender complies with ST 2110-22, the Sender resource MUST indicate the bit rate (kilobits/second) including the RTP transport overhead.
+  Otherwise, it is only RECOMMENDED that this attribute is included.
+  The `bit_rate` integer value is expressed in units of 1000 bits per second, rounding up.
+  The value is for the IP packets, including the RTP, UDP and IP packet headers and the payload.
+- [ST 2110-21 Sender Type](https://specs.amwa.tv/nmos-parameter-registers/branches/main/sender-attributes/#st-2110-21-sender-type)  
+  If the Sender complies with the traffic shaping and delivery timing requirements for ST 2110-22, it MUST include the `st2110_21_sender_type` attribute.
+
+An example Sender resource is provided in the [Examples](../examples/).
+
 ## JPEG XS IS-04 Receivers
 
 Nodes capable of receiving JPEG XS video streams MUST have a Receiver resource in the IS-04 Node API, which lists `video/jxsv` in the `media_types` array within the `caps` object.
@@ -85,13 +99,14 @@ Receivers are RECOMMENDED to use the following parameter constraints:
 - [Sublevel Bits Per Pixel](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#sublevel-bits-per-pixel)  
   When the JPEG XS decoder supports the Full (or Unrestricted) sublevel, the Receiver MAY indicate that this parameter is unconstrained, as per BCP-004-01.
 
-Receivers SHOULD also use other parameter constraints, such as those on coded video Flow attributes, where appropriate:
+Receivers SHOULD also use other parameter constraints, such as those on coded video Flow and Sender attributes, where appropriate:
 
 - [Frame Width](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#frame-width)
 - [Frame Height](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#frame-height)
 - [Color Sampling](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#color-sampling)
 - [Component Depth](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#component-depth)
-- [Bit Rate](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#bit-rate)
+- [Format Bit Rate](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#format-bit-rate)
+- [Transport Bit Rate](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#transport-bit-rate)
 
 If the Receiver supports streams meeting the traffic shaping and delivery timing requirements for ST 2110-22, it SHOULD use the [ST 2110-21 Sender Type](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#st-2110-21-sender-type) parameter constraint.
 

--- a/docs/NMOS With JPEG XS.md
+++ b/docs/NMOS With JPEG XS.md
@@ -57,6 +57,9 @@ In addition to those attributes defined in IS-04 for all coded video Flows, the 
   Otherwise, the `sublevel_bpp` value SHOULD indicate the compression ratio used by the encoder in bits per pixel as a number.
   When the precise value is not available, the value MUST be set based on the sublevel indicated in the codestream or in the SDP format-specific parameters defined by RFC 9134.
   For example, `Sublev6bpp` is indicated by the value `6`.
+- [Bit Rate](https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/#bit-rate)  
+  The Flow resource SHOULD indicate the target bit rate (kilobits/second) of the codestream.
+  The `bit_rate` integer value is expressed in units of 1000 bits per second, rounding up.
 
 An example Flow resource is provided in the [Examples](../examples/).
 
@@ -88,6 +91,7 @@ Receivers SHOULD also use other parameter constraints, such as those on coded vi
 - [Frame Height](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#frame-height)
 - [Color Sampling](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#color-sampling)
 - [Component Depth](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#component-depth)
+- [Bit Rate](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#bit-rate)
 
 If the Receiver supports streams meeting the traffic shaping and delivery timing requirements for ST 2110-22, it SHOULD use the [ST 2110-21 Sender Type](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#st-2110-21-sender-type) parameter constraint.
 

--- a/docs/NMOS With JPEG XS.md
+++ b/docs/NMOS With JPEG XS.md
@@ -79,7 +79,7 @@ In addition to those attributes defined in IS-04 for Senders, the following attr
   If the Sender complies with ST 2110-22, the Sender resource MUST indicate the bit rate (kilobits/second) including the RTP transport overhead.
   Otherwise, it is only RECOMMENDED that this attribute is included.
   The `bit_rate` integer value is expressed in units of 1000 bits per second, rounding up.
-  The value is for the IP packets, including the RTP, UDP and IP packet headers and the payload.
+  The value is for the IP packets, so for the RTP payload format per RFC 9134, that includes the RTP, UDP and IP packet headers and the payload.
 - [ST 2110-21 Sender Type](https://specs.amwa.tv/nmos-parameter-registers/branches/main/sender-attributes/#st-2110-21-sender-type)  
   If the Sender complies with the traffic shaping and delivery timing requirements for ST 2110-22, it MUST include the `st2110_21_sender_type` attribute.
 

--- a/docs/NMOS With JPEG XS.md
+++ b/docs/NMOS With JPEG XS.md
@@ -55,10 +55,9 @@ These attributes provide information for Controllers and Users to evaluate strea
   The Flow resource is strongly RECOMMENDED to indicate the JPEG XS level, which defines a lower bound on the required throughput for a decoder in the image (or decoded) domain.
   The permitted `level` values are strings, defined as per RFC 9134.
   The Unrestricted level is indicated by omitting this attribute.
-- [Sublevel Bits Per Pixel](https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/#sublevel-bits-per-pixel)  
+- [Sublevel](https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/#sublevel)  
   The Flow resource is strongly RECOMMENDED to indicate the JPEG XS sublevel, which defines a lower bound on the required throughput for a decoder in the codestream (or coded) domain.
-  The permitted `sublevel_bpp` values are integers, expressed in bits per pixel (BPP), corresponding to the sublevel.   
-  The Full sublevel is indicated by the number of bits per component multiplied by the number of components in the uncompressed image.
+  The permitted `sublevel` values are strings, defined as per RFC 9134.
   The Unrestricted sublevel is indicated by omitting this attribute.
 - [Bit Rate](https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/#bit-rate)  
   The Flow resource SHOULD indicate the target bit rate (kilobits/second) of the codestream.
@@ -99,9 +98,10 @@ Receivers are RECOMMENDED to use the following parameter constraints:
 
 - [Profile](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#profile)
 - [Level](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#level)
-- [Sublevel Bits Per Pixel](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#sublevel-bits-per-pixel)  
+- [Sublevel](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#sublevel)  
 
 When the JPEG XS decoder supports the Unrestricted profile, level or sublevel, the Receiver MAY indicate that the parameter is unconstrained, as described in BCP-004-01.
+When the decoder does not support Unrestricted but supports a range of profiles, levels or sublevels, the `enum` Constraint Keyword can be used to indicate the acceptable values.
 
 Receivers SHOULD also use other parameter constraints, such as those on coded video Flow and Sender attributes, where appropriate:
 

--- a/docs/NMOS With JPEG XS.md
+++ b/docs/NMOS With JPEG XS.md
@@ -23,28 +23,15 @@ and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119]
 
 The NMOS terms 'Node', 'Source', 'Flow', 'Sender', 'Receiver' are used as defined in the [NMOS Glossary](https://specs.amwa.tv/nmos/main/docs/Glossary.html).
 
-## JPEG XS IS-04 Receivers
+## JPEG XS IS-04 Sources, Flows and Senders
 
-Nodes capable of receiving JPEG XS video streams MUST have a Receiver resource in the IS-04 Node API, which lists `video/jxsv` in the `media_types` array within the `caps` object.
-This has been permitted since IS-04 v1.1.
+Nodes capable of transmitting JPEG XS video streams MUST have Source, Flow and Sender resources in the IS-04 Node API.
 
-Nodes implementing [BCP-004-01][] Receiver Capabilities use the existing `constraint_sets` parameter within the `caps` object, describing combinations of frame rates, width and height, and other parameters which the receiver can support, using the parameter constraints defined in the [Capabilities register](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/) of the [NMOS Parameter Registers][].
+### Sources
 
-If the Receiver supports streams meeting the traffic shaping and delivery timing requirements for ST 2110-22, it SHOULD use the `urn:x-nmos:cap:transport:st2110_21_sender_type` parameter constraint.
-
-An example Receiver resource is provided in the [Examples](../examples/).
-
-## JPEG XS IS-04 Senders, Flows and Sources
-
-Nodes capable of transmitting JPEG XS video streams MUST have Sender, Flow and Source resources in the IS-04 Node API.
-
-### Senders
-
-The Sender resource MUST indicate `urn:x-nmos:transport:rtp` or one of its subclassifications for the `transport` attribute.
-Sender resources provide no indication of media type or format, since this is described by the associated Flow resource.
-
-The SDP file at the `manifest_href` MUST comply with the requirements of RFC 9134.
-If the Sender meets the traffic shaping and delivery timing requirements specified for ST 2110-22, the SDP file MUST also comply with the provisions of ST 2110-22.
+The Source resource MUST indicate `urn:x-nmos:format:video` for the `format`.
+Source resources can be associated with many Flows at the same time.
+The Source is therefore unaffected by the use of JPEG XS compression.
 
 ### Flows
 
@@ -59,11 +46,24 @@ The bit rate value also appears in the SDP file, per RFC 9134.
 
 An example Flow resource is provided in the [Examples](../examples/).
 
-### Sources
+### Senders
 
-The Source resource MUST indicate `urn:x-nmos:format:video` for the `format`.
-Source resources can be associated with many Flows at the same time.
-The Source is therefore unaffected by the use of JPEG XS compression.
+The Sender resource MUST indicate `urn:x-nmos:transport:rtp` or one of its subclassifications for the `transport` attribute.
+Sender resources provide no indication of media type or format, since this is described by the associated Flow resource.
+
+The SDP file at the `manifest_href` MUST comply with the requirements of RFC 9134.
+If the Sender meets the traffic shaping and delivery timing requirements specified for ST 2110-22, the SDP file MUST also comply with the provisions of ST 2110-22.
+
+## JPEG XS IS-04 Receivers
+
+Nodes capable of receiving JPEG XS video streams MUST have a Receiver resource in the IS-04 Node API, which lists `video/jxsv` in the `media_types` array within the `caps` object.
+This has been permitted since IS-04 v1.1.
+
+Nodes implementing [BCP-004-01][] Receiver Capabilities use the existing `constraint_sets` parameter within the `caps` object, describing combinations of frame rates, width and height, and other parameters which the receiver can support, using the parameter constraints defined in the [Capabilities register](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/) of the [NMOS Parameter Registers][].
+
+If the Receiver supports streams meeting the traffic shaping and delivery timing requirements for ST 2110-22, it SHOULD use the `urn:x-nmos:cap:transport:st2110_21_sender_type` parameter constraint.
+
+An example Receiver resource is provided in the [Examples](../examples/).
 
 ## JPEG XS IS-05 Senders and Receivers
 

--- a/examples/jpeg-xs.sdp
+++ b/examples/jpeg-xs.sdp
@@ -6,6 +6,6 @@ m=video 30000 RTP/AVP 112
 c=IN IP4 224.1.1.1/64
 a=source-filter: incl IN IP4 224.1.1.1 192.168.1.2
 a=rtpmap:112 jxsv/90000
-a=fmtp:112 packetmode=0; sampling=YCbCr-4:2:2; width=1920; height=1080; exactframerate=50; depth=10; colorimetry=BT709; TCS=SDR; RANGE=FULL; SSN=ST2110-22:2019; TP=2110TPNL; 
+a=fmtp:112 packetmode=0; profile=High444.12; level=1k-1; sublevel=Sublev3bpp; sampling=YCbCr-4:2:2; width=1280; height=720; exactframerate=60000/1001; depth=10; colorimetry=BT709; TCS=SDR; RANGE=FULL; SSN=ST2110-22:2019; TP=2110TPN; 
 a=mediaclk:direct=0
 a=ts-refclk:localmac=40-a3-6b-a0-2b-d2

--- a/examples/jpeg-xs.sdp
+++ b/examples/jpeg-xs.sdp
@@ -4,6 +4,7 @@ s=SMPTE ST2110-22 JPEG XS
 t=0 0
 m=video 30000 RTP/AVP 112
 c=IN IP4 224.1.1.1/64
+b=AS:116000
 a=source-filter: incl IN IP4 224.1.1.1 192.168.1.2
 a=rtpmap:112 jxsv/90000
 a=fmtp:112 packetmode=0; profile=High444.12; level=1k-1; sublevel=Sublev3bpp; sampling=YCbCr-4:2:2; width=1280; height=720; exactframerate=60000/1001; depth=10; colorimetry=BT709; TCS=SDR; RANGE=FULL; SSN=ST2110-22:2019; TP=2110TPN; 

--- a/examples/nodeapi-flow.json
+++ b/examples/nodeapi-flow.json
@@ -1,7 +1,7 @@
 {
   "profile": "High444.12",
   "level": "1k-1",
-  "sublevel_bpp": 3,
+  "sublevel": "Sublev3bpp",
   "bit_rate": 110482,
   "frame_width": 1280,
   "frame_height": 720,

--- a/examples/nodeapi-flow.json
+++ b/examples/nodeapi-flow.json
@@ -1,7 +1,7 @@
 {
   "profile": "High444.12",
   "level": "1k-1",
-  "sublevel_bpp": 2,
+  "sublevel_bpp": 3,
   "bit_rate": 110482,
   "frame_width": 1280,
   "frame_height": 720,

--- a/examples/nodeapi-flow.json
+++ b/examples/nodeapi-flow.json
@@ -2,6 +2,7 @@
   "profile": "High444.12",
   "level": "1k-1",
   "sublevel_bpp": 2,
+  "bit_rate": 110482,
   "frame_width": 1280,
   "frame_height": 720,
   "interlace_mode": "progressive",

--- a/examples/nodeapi-flow.json
+++ b/examples/nodeapi-flow.json
@@ -1,4 +1,7 @@
 {
+  "profile": "High444.12",
+  "level": "1k-1",
+  "sublevel_bpp": 2,
   "frame_width": 1280,
   "frame_height": 720,
   "interlace_mode": "progressive",
@@ -12,7 +15,7 @@
   "format": "urn:x-nmos:format:video",
   "grain_rate": { "numerator": 60000, "denominator": 1001 },
   "source_id": "1d7f0019-d4c5-3fb5-b8ad-230cb0c017f3",
-  "device_id": "a98b537d-c628-3cf1-8afc-83076e3c757c",
+  "device_id": "2ed1ef00-5c0f-32b1-84b9-2def21489983",
   "parents": [],
   "media_type": "video/jxsv",
   "description": "Flow CustomHost [3,2,02]02 vs",

--- a/examples/nodeapi-receiver.json
+++ b/examples/nodeapi-receiver.json
@@ -46,8 +46,8 @@
         "urn:x-nmos:cap:format:level": {
           "enum": [ "1k-1" ]
         },
-        "urn:x-nmos:cap:format:sublevel_bpp": {
-          "maximum": 4
+        "urn:x-nmos:cap:format:sublevel": {
+          "enum": [ "Sublev3bpp", "Sublev4bpp" ]
         }
       }
     ],

--- a/examples/nodeapi-receiver.json
+++ b/examples/nodeapi-receiver.json
@@ -12,7 +12,43 @@
     ],
     "constraint_sets": [
       {
-        "urn:x-nmos:cap:meta:label": "TO DO"
+        "urn:x-nmos:cap:meta:label": "VSF TR-08 Capability Set A Interop Point 1",
+        "urn:x-nmos:cap:format:frame_width": {
+          "enum": [ 1280 ]
+        },
+        "urn:x-nmos:cap:format:frame_height": {
+          "enum": [ 720 ]
+        },
+        "urn:x-nmos:cap:format:interlace_mode": {
+          "enum": [ "progressive" ]
+        },
+        "urn:x-nmos:cap:format:grain_rate": {
+          "enum": [
+            { "numerator": 60000, "denominator": 1001 }
+          ]
+        },
+        "urn:x-nmos:cap:format:bit_rate": {
+          "minimum": 82862,
+          "maximum": 220964
+        },
+        "urn:x-nmos:cap:format:component_depth": {
+          "enum": [ 10 ]
+        },
+        "urn:x-nmos:cap:format:color_sampling": {
+          "enum": [ "YCbCr-4:2:2" ]
+        },
+        "urn:x-nmos:cap:format:colorspace": {
+          "enum": [ "BT709" ]
+        },
+        "urn:x-nmos:cap:format:profile": {
+          "enum": [ "High444.12" ]
+        },
+        "urn:x-nmos:cap:format:level": {
+          "enum": [ "1k-1" ]
+        },
+        "urn:x-nmos:cap:format:sublevel_bpp": {
+          "maximum": 4
+        }
       }
     ],
     "version": "1635445227:652000"

--- a/examples/nodeapi-sender.json
+++ b/examples/nodeapi-sender.json
@@ -1,0 +1,20 @@
+{
+  "device_id": "2ed1ef00-5c0f-32b1-84b9-2def21489983",
+  "transport": "urn:x-nmos:transport:rtp.mcast",
+  "subscription": {
+    "receiver_id": null,
+    "active": true
+  },
+  "caps": {},
+  "interface_bindings": [
+    "eth0"
+  ],
+  "manifest_href": "http://192.168.1.2/x-manufacturer/senders/88598159-689f-3388-90ae-7fba6cee5f6e/stream.sdp",
+  "description": "",
+  "tags": {},
+  "id": "88598159-689f-3388-90ae-7fba6cee5f6e",
+  "flow_id": "58e3d42f-2b78-3f9c-8134-8b07c6176bf0",
+  "version": "1636518564:223000",
+  "label": ""
+}
+


### PR DESCRIPTION
Replaces #10 based on latest approach of NMOS Stream Mappings activity group.
Depends on https://github.com/AMWA-TV/nmos-parameter-registers/pull/43.

Specifies the use of the following new Flow attributes and related Receiver parameter constraints
* `profile` and `urn:x-nmos:cap:format:profile`
* `level` and `urn:x-nmos:cap:format:level`
* `sublevel_bpp` and `urn:x-nmos:cap:format:sublevel_bpp`
* `bit_rate` and `urn:x-nmos:cap:format:bit_rate`

Specifies the use of the following new Sender attributes and related Receiver parameter constraints
* `bit_rate` and `urn:x-nmos:cap:transport:bit_rate`, i.e. including the transport overhead
* `st2110_21_sender_type` and `urn:x-nmos:cap:transport:st2110_21_sender_type`

To be reviewed by @AMWA-TV/nmos-architecture-review group as well as the activity group.