### PR TITLE
Strengthen requirement for BCP-004-01 Receiver Capabilities

### DIFF
--- a/docs/NMOS With JPEG XS.md
+++ b/docs/NMOS With JPEG XS.md
@@ -95,19 +95,19 @@ An example Sender resource is provided in the [Examples](../examples/).
 Nodes capable of receiving JPEG XS video streams MUST have a Receiver resource in the IS-04 Node API, which lists `video/jxsv` in the `media_types` array within the `caps` object.
 This has been permitted since IS-04 v1.1.
 
-Nodes implementing [BCP-004-01][] Receiver Capabilities use the existing `constraint_sets` parameter within the `caps` object, describing combinations of frame rates, width and height, and other parameters which the receiver can support, using the parameter constraints defined in the [Capabilities register](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/) of the NMOS Parameter Registers.
+If the Receiver has limitations on the JPEG XS video streams that it supports, the Receiver resource MUST indicate the constraints using [BCP-004-01][] Receiver Capabilities. The `constraint_sets` parameter within the `caps` object can be used to describe combinations of frame rates, width and height, and other parameters which the receiver can support, using the parameter constraints defined in the [Capabilities register](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/) of the NMOS Parameter Registers.
 
-Receivers are RECOMMENDED to use the following parameter constraints:
+The following parameter constraints have been registered initially for use with JPEG XS:
 
 - [Profile](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#profile)
 - [Level](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#level)
 - [Sublevel](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#sublevel)  
 - [Packet Transmission Mode](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#packet-transmission-mode)  
 
-When the JPEG XS decoder supports the Unrestricted profile, level or sublevel, the Receiver MAY indicate that the parameter is unconstrained, as described in BCP-004-01.
+When the JPEG XS decoder supports the Unrestricted profile, level or sublevel, the Receiver can indicate that the parameter is unconstrained, as described in BCP-004-01.
 When the decoder does not support Unrestricted but supports a range of profiles, levels or sublevels, the `enum` Constraint Keyword can be used to indicate the acceptable values.
 
-Receivers SHOULD also use other parameter constraints, such as those on coded video Flow and Sender attributes, where appropriate:
+Other parameter constraints, such as the following ones on coded video Flow and Sender attributes, are also appropriate for use with JPEG XS:
 
 - [Frame Width](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#frame-width)
 - [Frame Height](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#frame-height)
@@ -115,10 +115,9 @@ Receivers SHOULD also use other parameter constraints, such as those on coded vi
 - [Component Depth](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#component-depth)
 - [Format Bit Rate](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#format-bit-rate)
 - [Transport Bit Rate](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#transport-bit-rate)
+- [ST 2110-21 Sender Type](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#st-2110-21-sender-type)
 
-If the Receiver supports streams meeting the traffic shaping and delivery timing requirements for ST 2110-22, it SHOULD use the [ST 2110-21 Sender Type](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#st-2110-21-sender-type) parameter constraint.
-
-An example Receiver resource is provided in the [Examples](../examples/).
+An example Receiver resource is provided in the [Examples](../examples/) that demonstrates how to represent VSF TR-08 interoperability points using these parameter constraints.
 
 ## JPEG XS IS-05 Senders and Receivers
 

--- a/docs/NMOS With JPEG XS.md
+++ b/docs/NMOS With JPEG XS.md
@@ -95,7 +95,8 @@ An example Sender resource is provided in the [Examples](../examples/).
 Nodes capable of receiving JPEG XS video streams MUST have a Receiver resource in the IS-04 Node API, which lists `video/jxsv` in the `media_types` array within the `caps` object.
 This has been permitted since IS-04 v1.1.
 
-If the Receiver has limitations on the JPEG XS video streams that it supports, the Receiver resource MUST indicate the constraints using [BCP-004-01][] Receiver Capabilities. The `constraint_sets` parameter within the `caps` object can be used to describe combinations of frame rates, width and height, and other parameters which the receiver can support, using the parameter constraints defined in the [Capabilities register](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/) of the NMOS Parameter Registers.
+If the Receiver has limitations on the JPEG XS video streams that it supports, the Receiver resource MUST indicate the constraints using [BCP-004-01][] Receiver Capabilities.
+The `constraint_sets` parameter within the `caps` object can be used to describe combinations of frame rates, width and height, and other parameters which the receiver can support, using the parameter constraints defined in the [Capabilities register](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/) of the NMOS Parameter Registers.
 
 The following parameter constraints can be used to express limits specifically defined by ISO/IEC 21122 and RFC 9134 for JPEG XS decoders:
 

--- a/docs/NMOS With JPEG XS.md
+++ b/docs/NMOS With JPEG XS.md
@@ -97,7 +97,7 @@ This has been permitted since IS-04 v1.1.
 
 If the Receiver has limitations on the JPEG XS video streams that it supports, the Receiver resource MUST indicate the constraints using [BCP-004-01][] Receiver Capabilities. The `constraint_sets` parameter within the `caps` object can be used to describe combinations of frame rates, width and height, and other parameters which the receiver can support, using the parameter constraints defined in the [Capabilities register](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/) of the NMOS Parameter Registers.
 
-The following parameter constraints have been registered initially for use with JPEG XS:
+The following parameter constraints can be used to express limits specifically defined by ISO/IEC 21122 and RFC 9134 for JPEG XS decoders:
 
 - [Profile](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#profile)
 - [Level](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#level)
@@ -107,7 +107,7 @@ The following parameter constraints have been registered initially for use with 
 When the JPEG XS decoder supports the Unrestricted profile, level or sublevel, the Receiver can indicate that the parameter is unconstrained, as described in BCP-004-01.
 When the decoder does not support Unrestricted but supports a range of profiles, levels or sublevels, the `enum` Constraint Keyword can be used to indicate the acceptable values.
 
-Other parameter constraints, such as the following ones on coded video Flow and Sender attributes, are also appropriate for use with JPEG XS:
+Other existing parameter constraints, such as the following, are also appropriate to express limitations on supported JPEG XS video streams:
 
 - [Frame Width](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#frame-width)
 - [Frame Height](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#frame-height)


### PR DESCRIPTION
Although it will be challenging/impossible to determine in an automated test case if the advertised constraints match the actual implementation constraints, the spec should state clearly that Receiver caps MUST be used to describe constraints for JPEG XS. (The parameter constraints can be checked for valid syntax/enum values, etc. of course.)
