### PR TITLE
Tweak wording to indicate the rules of BCP-004-01 apply

### DIFF
--- a/docs/NMOS With JPEG XS.md
+++ b/docs/NMOS With JPEG XS.md
@@ -95,7 +95,7 @@ An example Sender resource is provided in the [Examples](../examples/).
 Nodes capable of receiving JPEG XS video streams MUST have a Receiver resource in the IS-04 Node API, which lists `video/jxsv` in the `media_types` array within the `caps` object.
 This has been permitted since IS-04 v1.1.
 
-If the Receiver has limitations on the JPEG XS video streams that it supports, the Receiver resource MUST indicate the constraints using [BCP-004-01][] Receiver Capabilities.
+If the Receiver has limitations on the JPEG XS video streams that it supports, the Receiver resource MUST indicate constraints in accordance with the [BCP-004-01][] Receiver Capabilities specification.
 The `constraint_sets` parameter within the `caps` object can be used to describe combinations of frame rates, width and height, and other parameters which the receiver can support, using the parameter constraints defined in the [Capabilities register](https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/) of the NMOS Parameter Registers.
 
 The following parameter constraints can be used to express limits specifically defined by ISO/IEC 21122 and RFC 9134 for JPEG XS decoders:


### PR DESCRIPTION
Following Slack discussion and activity group call, 13 July, we want to clarify that the use of `constraint_sets` is per BCP-004-01 [Behaviour: Receivers](https://github.com/AMWA-TV/bcp-004-01/blob/v1.0.x/docs/Receiver%20Capabilities.md#behaviour-receivers):

> Receivers SHOULD express their capabilities as precisely as possible, using the relevant Parameter Constraints listed in the Capabilities register in the [NMOS Parameter Registers](https://specs.amwa.tv/nmos-parameter-registers/). However, this specification may not be sufficiently expressive to indicate every type of stream that a Receiver can or cannot consume successfully. It is entirely possible that a Receiver may fail to consume a stream even if the Receiver's advertised Constraint Sets indicate that it can.
