### PR TITLE
Additional requirements on SDP files of JPEG XS Senders

### DIFF
--- a/docs/NMOS With JPEG XS.md
+++ b/docs/NMOS With JPEG XS.md
@@ -71,11 +71,11 @@ For Nodes transmitting JPEG XS using the RTP payload mapping defined by RFC 9134
 Sender resources provide no indication of media type or format, since this is described by the associated Flow resource.
 
 The SDP file at the `manifest_href` MUST comply with the requirements of RFC 9134.
-Additionally, the SDP file MUST convey, so far as the defined parameters allow, the same information about the stream as conveyed by the Source, Flow and Sender attributes defined by this specification and IS-04.
+Additionally, the SDP file needs to convey, so far as the defined parameters allow, the same information about the stream as conveyed by the Source, Flow and Sender attributes defined by this specification and IS-04.
 Therefore:
 
 - Each of the `profile`, `level` and `sublevel` format-specific parameters MUST be included with the correct value unless it is Unrestricted.
-- The correct `sampling`, `depth`, `width`, `height`, `exactframerate` and `colorimetry` MUST always be included.
+- The correct `sampling`, `depth`, `width`, `height`, `exactframerate` and `colorimetry` MUST be included in all cases.
 - The `interlace` and `segmented` parameters MUST be included or omitted to correctly indicate the scanning/interlace mode.
 
 If the Sender meets the traffic shaping and delivery timing requirements specified for ST 2110-22, the SDP file MUST also comply with the provisions of ST 2110-22.
@@ -140,8 +140,8 @@ A `PATCH` request on the **/staged** endpoint of an IS-05 Receiver can contain a
 The SDP file for a JPEG XS stream is expected to comply with RFC 9134 and, if appropriate, ST 2110-22.
 It need not comply with the additional requirements specified for SDP files at Senders.
 
-The Receiver SHOULD evaluate whether it would not be capable of consuming the stream and reject the request if so.
-The Receiver SHOULD NOT reject the request just because it is unable to assess the stream compatibility, for example when the SDP file does not include some of the optional parameters defined by RFC 9134.
+If the Receiver is not capable of consuming the stream described by the SDP file, it SHOULD reject the request.
+If it is unable to assess the stream compatibility, for example when the SDP file does not include some of the optional parameters defined by RFC 9134, it MAY accept the request.
 
 An example SDP file is provided in the [Examples](../examples/).
 

--- a/docs/NMOS With JPEG XS.md
+++ b/docs/NMOS With JPEG XS.md
@@ -71,7 +71,8 @@ For Nodes transmitting JPEG XS using the RTP payload mapping defined by RFC 9134
 Sender resources provide no indication of media type or format, since this is described by the associated Flow resource.
 
 The SDP file at the `manifest_href` MUST comply with the requirements of RFC 9134.
-Additionally, the SDP file MUST convey, so far as the defined parameters allow, the same information about the stream as conveyed by the Source, Flow and Sender attributes.
+Additionally, the SDP file MUST convey, so far as the defined parameters allow, the same information about the stream as conveyed by the Source, Flow and Sender attributes defined by this specification and IS-04.
+Therefore:
 
 - Each of the `profile`, `level` and `sublevel` format-specific parameters MUST be included with the correct value unless it is Unrestricted.
 - The correct `sampling`, `depth`, `width`, `height`, `exactframerate` and `colorimetry` MUST always be included.
@@ -132,11 +133,15 @@ An example Receiver resource is provided in the [Examples](../examples/) that de
 ## JPEG XS IS-05 Senders and Receivers
 
 Connection Management using IS-05 proceeds in exactly the same manner as for any other stream format carried within RTP.
-The SDP file at the **/transportfile** endpoint on Senders MUST comply with the same requirements described for the SDP file at the IS-04 Sender `manifest_href`.
 
-An SDP file provided in the `transport_file` attribute of a `PATCH` request on the **/staged** endpoint of Receivers MUST also comply with RFC 9134 and, if appropriate, ST 2110-22.
-However, a Receiver MUST handle such an SDP file that does not comply with the additional requirements described for Senders.
-When processing a request, a Receiver SHOULD use the parameters in the SDP file to evaluate if it would not be capable of consuming the stream.
+The SDP file at the **/transportfile** endpoint on an IS-05 Sender MUST comply with the same requirements described for the SDP file at the IS-04 Sender `manifest_href`.
+
+A `PATCH` request on the **/staged** endpoint of an IS-05 Receiver can contain an SDP file in the `transport_file` attribute.
+The SDP file for a JPEG XS stream is expected to comply with RFC 9134 and, if appropriate, ST 2110-22.
+It need not comply with the additional requirements specified for SDP files at Senders.
+
+The Receiver SHOULD evaluate whether it would not be capable of consuming the stream and reject the request if so.
+The Receiver SHOULD NOT reject the request just because it is unable to assess the stream compatibility, for example when the SDP file does not include some of the optional parameters defined by RFC 9134.
 
 An example SDP file is provided in the [Examples](../examples/).
 

--- a/docs/NMOS With JPEG XS.md
+++ b/docs/NMOS With JPEG XS.md
@@ -71,8 +71,11 @@ For Nodes transmitting JPEG XS using the RTP payload mapping defined by RFC 9134
 Sender resources provide no indication of media type or format, since this is described by the associated Flow resource.
 
 The SDP file at the `manifest_href` MUST comply with the requirements of RFC 9134.
-Additionally, the format-specific parameters defined by RFC 9134 are made REQUIRED in the same circumstances that a corresponding Flow attribute MUST be included, in order that the information provided to an NMOS Controller through a Flow is also provided to a Receiver through the SDP file.
-This means that `profile`, `level`, `sublevel`, `sampling`, `depth`, `width`, `height`, `exactframerate`, `colorimetry`, `interlace` and `segmented` are all REQUIRED depending on the properties of the JPEG XS stream.
+Additionally, the SDP file MUST convey, so far as the defined parameters allow, the same information about the stream as conveyed by the Source, Flow and Sender attributes.
+
+- Each of the `profile`, `level` and `sublevel` format-specific parameters MUST be included with the correct value unless it is Unrestricted.
+- The correct `sampling`, `depth`, `width`, `height`, `exactframerate` and `colorimetry` MUST always be included.
+- The `interlace` and `segmented` parameters MUST be included or omitted to correctly indicate the scanning/interlace mode.
 
 If the Sender meets the traffic shaping and delivery timing requirements specified for ST 2110-22, the SDP file MUST also comply with the provisions of ST 2110-22.
 
@@ -132,7 +135,8 @@ Connection Management using IS-05 proceeds in exactly the same manner as for any
 The SDP file at the **/transportfile** endpoint on Senders MUST comply with the same requirements described for the SDP file at the IS-04 Sender `manifest_href`.
 
 An SDP file provided in the `transport_file` attribute of a `PATCH` request on the **/staged** endpoint of Receivers MUST also comply with RFC 9134 and, if appropriate, ST 2110-22.
-Note that Receivers MUST handle such SDP files that do not comply with the additional requirements described for Senders.
+However, a Receiver MUST handle such an SDP file that does not comply with the additional requirements described for Senders.
+When processing a request, a Receiver SHOULD use the parameters in the SDP file to evaluate if it would not be capable of consuming the stream.
 
 An example SDP file is provided in the [Examples](../examples/).
 

--- a/docs/NMOS With JPEG XS.md
+++ b/docs/NMOS With JPEG XS.md
@@ -71,6 +71,9 @@ For Nodes transmitting JPEG XS using the RTP payload mapping defined by RFC 9134
 Sender resources provide no indication of media type or format, since this is described by the associated Flow resource.
 
 The SDP file at the `manifest_href` MUST comply with the requirements of RFC 9134.
+Additionally, the format-specific parameters defined by RFC 9134 are made REQUIRED in the same circumstances that a corresponding Flow attribute MUST be included, in order that the information provided to an NMOS Controller through a Flow is also provided to a Receiver through the SDP file.
+This means that `profile`, `level`, `sublevel`, `sampling`, `depth`, `width`, `height`, `exactframerate`, `colorimetry`, `interlace` and `segmented` are all REQUIRED depending on the properties of the JPEG XS stream.
+
 If the Sender meets the traffic shaping and delivery timing requirements specified for ST 2110-22, the SDP file MUST also comply with the provisions of ST 2110-22.
 
 For Nodes implementing IS-04 v1.3 or higher, the following additional requirements on the Sender resource apply.
@@ -126,9 +129,10 @@ An example Receiver resource is provided in the [Examples](../examples/) that de
 ## JPEG XS IS-05 Senders and Receivers
 
 Connection Management using IS-05 proceeds in exactly the same manner as for any other stream format carried within RTP.
-The SDP file at the **/transportfile** endpoint on Senders MUST comply with the requirements of RFC 9134 and, if appropriate, ST 2110-22.
+The SDP file at the **/transportfile** endpoint on Senders MUST comply with the same requirements described for the SDP file at the IS-04 Sender `manifest_href`.
 
 An SDP file provided in the `transport_file` attribute of a `PATCH` request on the **/staged** endpoint of Receivers MUST also comply with RFC 9134 and, if appropriate, ST 2110-22.
+Note that Receivers MUST handle such SDP files that do not comply with the additional requirements described for Senders.
 
 An example SDP file is provided in the [Examples](../examples/).
 


### PR DESCRIPTION
Resolving #18 based on activity group input.

Not sure whether we need to also explicitly add some of the transport-related parameters to the list of "REQUIRED depending" ones, like `transmode` from RFC 9134 (needed if `T` is 0), `b=AS:` (used by ST 2110-22, but we require the Sender attribute `bit_rate` always) and `TP` (`st2110_21_sender_type`), etc.
